### PR TITLE
Fix: do not split "New to Sqitch?" link

### DIFF
--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -360,6 +360,10 @@ main > section:first-of-type { border: none !important; }
 #hi a:before, #download a:before { font-family: fawe; margin-right: 7px; }
 #hi a:hover, #hi a:active { text-decoration: none; background-color: #e8f0fa; color:#22538e !important }
 
+#hi a[href="/about/"] {
+    white-space: nowrap;
+}
+
 .about:before { content: "\f05a" }
 .docs:before { content: "\f02d" }
 .community:before { content: "\f086" }

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -360,7 +360,7 @@ main > section:first-of-type { border: none !important; }
 #hi a:before, #download a:before { font-family: fawe; margin-right: 7px; }
 #hi a:hover, #hi a:active { text-decoration: none; background-color: #e8f0fa; color:#22538e !important }
 
-#hi a[href="/about/"] {
+#hi a {
     white-space: nowrap;
 }
 


### PR DESCRIPTION
On narrow screens it looks visually broken as it goes on two rows.

With new rule it will remain button like form and move it onto new row as a whole.

![screenshot](https://user-images.githubusercontent.com/210566/59110594-23a24b00-8948-11e9-851e-c22dfbedfa9d.jpg)
