### PR TITLE
Revise Sqitch installation instructions for Red Hat

### DIFF
--- a/content/download/redhat.md
+++ b/content/download/redhat.md
@@ -1,14 +1,24 @@
 ---
 title: "Sqitch on Red Hat"
-description: Install dependencies with Yum and Sqitch with cpanminus.
+description: Install dependencies with DNF or Yum and Sqitch with cpanminus.
 id: install
 ---
 
 {{% section class="redhat" %}}
 
 On Red Hat-derived systems (including CentOS, Fedora, Scientific, Oracle, etc.),
-use [Yum] to install dependencies, and then build Sqitch itself via [cpanminus].
-For example, to install Sqitch with support for [PostgreSQL]:
+use [DNF] or [Yum] to install dependencies, and then build Sqitch itself via
+[cpanminus].
+
+For example, to install Sqitch with support for [PostgreSQL] On newer
+DNF/DNF5‑based systems (e.g., Fedora 41+):
+
+    sudo dnf install perl-devel perl-CPAN postgresql-devel
+    sudo dnf group install development-tools
+    curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+    cpanm --sudo --quiet --notest App::Sqitch
+
+On older Yum‑based systems:
 
     sudo yum install perl-devel perl-CPAN postgresql perl-DBD-Pg
     sudo yum group install "Development Tools"
@@ -24,6 +34,7 @@ The client and connection libraries for each engine are:
 *   Firebird: `firebird-classic perl-DBD-Firebird perl-Time-HiRes`
 *   Vertica, Exasol, Snowflake, ClickHouse: `perl-DBD-ODBC`
 
+  [DNF]: https://docs.fedoraproject.org/en-US/quick-docs/dnf/
   [Yum]: http://yum.baseurl.org
   [cpanminus]: https://cpanmin.us
   [PostgreSQL]: https://postgresql.org/


### PR DESCRIPTION
Updated the installation instructions for Sqitch on Red Hat-derived systems to include DNF as an alternative to Yum.

On newer Fedora/RHEL systems, the default system Perl locations are owned by root and not writable by regular users. The old `cpanm --quiet --notest App::Sqitch` in the docs therefore installs **sqitch** into a user‑local Perl tree instead of the system one, so sqitch is not found in the global PATH.

Using `cpanm --sudo App::Sqitch` instead ensures the Sqitch command is installed in the system‑wide Perl directories where it can be used by all users, without requiring people to run the whole build step as root.

Tested on Fedora 43